### PR TITLE
Feature/modernise ios 16 oportunities

### DIFF
--- a/Onboarding/Sources/Onboarding/Views/OnboardingContainerView.swift
+++ b/Onboarding/Sources/Onboarding/Views/OnboardingContainerView.swift
@@ -11,6 +11,9 @@ struct OnboardingContainerView: View {
     }
 
     var body: some  View {
+        let layout = verticalSizeClass == .compact ?
+        AnyLayout(HStackLayout()) :
+        AnyLayout(VStackLayout())
         switch viewModel.state {
         case .loading:
             ProgressView()
@@ -37,7 +40,7 @@ struct OnboardingContainerView: View {
                             viewModel?.trackPageControllerPressEvent()
                         }
                     )
-                    AdaptiveStack {
+                    layout {
                         SwiftUIButton(
                             .primary,
                             viewModel: viewModel.primaryButtonViewModel
@@ -74,6 +77,7 @@ struct OnboardingContainerView: View {
         viewModel.isLastSlide == false
     }
 }
+
 #Preview {
     let viewModel = OnboardingContainerViewModel(
         onboardingService: OnboardingService(),

--- a/Onboarding/Sources/Onboarding/Views/OnboardingSlideView.swift
+++ b/Onboarding/Sources/Onboarding/Views/OnboardingSlideView.swift
@@ -5,14 +5,12 @@ import UIComponents
 struct OnboardingSlideView: View {
     private var model: OnboardingSlide
     @Environment(\.verticalSizeClass) var verticalSizeClass
-
-    enum FocusableFields: Hashable {
+    private enum FocusableLabels: Hashable {
         case title
         case body
     }
-
     @AccessibilityFocusState(for: .voiceOver)
-    private var focus: FocusableFields?
+    private var focus: FocusableLabels?
 
     init(model: OnboardingSlide) {
         self.model = model

--- a/Onboarding/Sources/Onboarding/Views/OnboardingSlideView.swift
+++ b/Onboarding/Sources/Onboarding/Views/OnboardingSlideView.swift
@@ -47,7 +47,7 @@ struct OnboardingSlideView: View {
                         .accessibilityFocused($focus, equals: .body)
                         .padding([.top, .leading, .trailing], 16)
                 Spacer()
-            }
+            }.accessibilityElement(children: .contain)
         }
     }
 }

--- a/Onboarding/Sources/Onboarding/Views/OnboardingSlideView.swift
+++ b/Onboarding/Sources/Onboarding/Views/OnboardingSlideView.swift
@@ -6,6 +6,14 @@ struct OnboardingSlideView: View {
     private var model: OnboardingSlide
     @Environment(\.verticalSizeClass) var verticalSizeClass
 
+    enum FocusableFields: Hashable {
+        case title
+        case body
+    }
+
+    @AccessibilityFocusState(for: .voiceOver)
+    private var focus: FocusableFields?
+
     init(model: OnboardingSlide) {
         self.model = model
     }
@@ -23,7 +31,6 @@ struct OnboardingSlideView: View {
                         .frame(width: 225, height: 225)
                         .padding([.bottom])
                 }
-                VStack {
                     Text(model.title)
                         .foregroundColor(Color(UIColor.govUK.text.primary))
                         .font(.title)
@@ -34,14 +41,15 @@ struct OnboardingSlideView: View {
                         .padding(.top, verticalSizeClass == .compact ? 32 : 0)
                         .padding([.trailing, .leading], 16)
                         .accessibilityAddTraits(.isHeader)
+                        .accessibilityFocused($focus, equals: .title)
                     Text(model.body)
                         .foregroundColor(Color(UIColor.govUK.text.primary))
                         .multilineTextAlignment(.center)
                         .accessibilityLabel(Text(model.body))
+                        .accessibilityFocused($focus, equals: .body)
                         .padding([.top, .leading, .trailing], 16)
-                    }
                 Spacer()
-            }.accessibilityElement(children: .contain)
+            }
         }
     }
 }


### PR DESCRIPTION
This pr removes the use of the adaptive stack  and instead uses the new Anylayout feature. it also removes the accessibility groupings in place for focus state  wrapper features which would come in even more use when we use text fields with swift ui. 

The downsides with the Anylayout is that to make it reusable we would  need to make a generic struct with a viewbuilder almost similar to the adaptive stack. I have also looked at apples examples and this appears to be in line with how there are using it  and would have been the approach i would have initially taken if this was available. Also because of the new VStackLayouts and HStackLayouts my take is that we would end up using them more  directly in our views aswell 

Currently looking at sonar issue